### PR TITLE
fix: raise FAB z-index above Leaflet panes

### DIFF
--- a/trail.html
+++ b/trail.html
@@ -225,7 +225,7 @@
       cursor: pointer;
       box-shadow: var(--shadow-lg), 0 0 0 1px rgba(200,135,74,0.15);
       display: flex; align-items: center; justify-content: center;
-      z-index: 400;
+      z-index: 1000;
       transition: opacity 0.3s, background 0.15s, color 0.15s;
       -webkit-tap-highlight-color: transparent;
     }
@@ -243,7 +243,7 @@
       cursor: pointer;
       box-shadow: var(--shadow-lg);
       display: flex; align-items: center; justify-content: center;
-      z-index: 400;
+      z-index: 1000;
       transition: opacity 0.3s, background 0.15s;
       -webkit-tap-highlight-color: transparent;
     }
@@ -266,7 +266,7 @@
       cursor: pointer;
       box-shadow: var(--shadow-lg);
       display: flex; align-items: center; gap: 7px;
-      z-index: 400;
+      z-index: 1000;
       transition: background 0.15s, border-color 0.15s;
       white-space: nowrap;
       -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
FAB buttons had z-index: 400, matching Leaflet's .leaflet-map-pane. Since Leaflet appends its pane after the buttons in the DOM, the map pane painted over the buttons at equal z-index, causing them to disappear after a brief flash on page load.

Raises all three FABs to z-index: 1000, above Leaflet's highest pane (popup-pane at 700).

Fixes #7

Generated with [Claude Code](https://claude.ai/code)