### PR TITLE
fix: trail card height on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
     .route-card {
       position: absolute;
       width: min(88vw, 340px);
+      height: 460px;
       background: rgba(24, 38, 24, 0.82);
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px);
@@ -223,7 +224,7 @@
     }
 
     @media (min-width: 640px) {
-      .route-card { width: min(42vw, 380px); }
+      .route-card { width: min(42vw, 380px); height: 510px; }
     }
 
     /* ── Carousel dots ───────────────────────────────────────────── */


### PR DESCRIPTION
Fixes #9

Adds explicit height to trail cards on mobile so the terrain hero background fills the full card area. Without a defined height, the absolutely-positioned card-terrain layer had no dimensions and cards appeared as small content strips.

Generated with [Claude Code](https://claude.ai/code)